### PR TITLE
Limit raw torrent retention to hash-bounded cache

### DIFF
--- a/torbox-lampa-plugin.js
+++ b/torbox-lampa-plugin.js
@@ -974,12 +974,10 @@ try {
       );
     };
 
-    const rawTorrentByView = new WeakMap();
     const rawTorrentByHash = new Map();
     let debugOverlayEl = null;
 
-    const storeRawTorrent = (hash, raw, viewItem) => {
-      if (viewItem && raw) rawTorrentByView.set(viewItem, raw);
+    const storeRawTorrent = (hash, raw) => {
       if (!hash || !raw) return;
       rawTorrentByHash.delete(hash);
       rawTorrentByHash.set(hash, raw);
@@ -1555,7 +1553,7 @@ try {
         tech_bar_html: this.buildTechBar(tech, raw),
       };
 
-      storeRawTorrent(hashHex, raw, viewItem);
+      storeRawTorrent(hashHex, raw);
       return viewItem;
     };
 


### PR DESCRIPTION
### Motivation
- The plugin previously attached the full untrusted tracker parser response to each rendered view item, which allowed a malicious tracker to bloat memory and cause client-side OOM/DoS. 
- The goal is to eliminate redundant strong references to raw tracker payloads while preserving existing raw lookup by hash and overall functionality.

### Description
- Removed per-item `WeakMap` retention by deleting `rawTorrentByView` and the `viewItem` parameter from `storeRawTorrent` in `torbox-lampa-plugin.js`. 
- Changed the storage API to `storeRawTorrent(hash, raw)` and updated `toViewItem` to call `storeRawTorrent(hashHex, raw)` without embedding `raw` into the view object. 
- Kept the existing bounded `rawTorrentByHash` map with `CONST.RAW_CACHE_HASH_LIMIT` to limit retained raw payloads by hash and preserve flows that retrieve raw data via hash.

### Testing
- Ran `node --check torbox-lampa-plugin.js` which completed without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af2c16c830832b9be562df35ac7aee)