### PR TITLE
Update built-in parser host

### DIFF
--- a/torbox-lampa-plugin.js
+++ b/torbox-lampa-plugin.js
@@ -46,7 +46,7 @@ try {
   const PUBLIC_PARSERS = [
     // These are TorBox-compatible tracker indexer gateways frequently used by Lampa plugins.
     // If one is down, the next will be tried.
-    { name: 'Viewbox', url: 'jacred.viewbox.dev', key: 'viewbox' },
+    { name: 'MaxVol', url: 'jr.maxvol.pro', key: '' },
     { name: 'Jacred', url: 'jacred.xyz', key: '' },
   ];
 


### PR DESCRIPTION
## Summary
- replace the dead default `jacred.viewbox.dev` parser host with the live `jr.maxvol.pro` endpoint
- keep the existing fallback order shape while restoring real search results out of the box

## Verification
- live checked `jr.maxvol.pro` and confirmed it returns valid JSON results for movie queries
- node scripts/validate.js
- node --test tests/unit/torbox-pure.test.js
