### PR TITLE
fix: validate TorBox download URLs

### DIFF
--- a/tests/unit/torbox-pure.test.js
+++ b/tests/unit/torbox-pure.test.js
@@ -691,6 +691,10 @@ test('file download starts a download path after requestdl resolves', () => {
   const pluginPath = path.resolve(__dirname, '..', '..', 'torbox-lampa-plugin.js');
   const plugin = fs.readFileSync(pluginPath, 'utf8');
 
+  assert.match(plugin, /const normalizeSafeDownloadLink = \(link\) =>/);
+  assert.match(plugin, /const url = new URL\(link\.trim\(\)\);/);
+  assert.match(plugin, /url\.protocol !== 'http:' && url\.protocol !== 'https:'\) return null;/);
+  assert.match(plugin, /const link = normalizeSafeDownloadLink\(dl\?\.url \|\| dl\?\.data\);/);
   assert.match(plugin, /const getFileDownloadFilename = \(file\) =>/);
   assert.match(plugin, /const prepareFileDownloadOpen = \(file\) =>/);
   assert.match(plugin, /const startFileDownload = \(link, file, opener\) =>/);

--- a/torbox-lampa-plugin.js
+++ b/torbox-lampa-plugin.js
@@ -2123,10 +2123,22 @@ try {
         })[0] || null;
     };
 
+    const normalizeSafeDownloadLink = (link) => {
+      if (!link || typeof link !== 'string') return null;
+
+      try {
+        const url = new URL(link.trim());
+        if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+        return url.href;
+      } catch (_) {
+        return null;
+      }
+    };
+
     const resolveFileDownloadLink = async (torrentData, file) => {
       const dl = await Api.requestDl(torrentData.id, file.id);
-      const link = dl?.url || dl?.data;
-      if (!link || typeof link !== 'string') throw { type: 'api', message: translate('torbox_error_file_link') };
+      const link = normalizeSafeDownloadLink(dl?.url || dl?.data);
+      if (!link) throw { type: 'api', message: translate('torbox_error_file_link') };
       return link;
     };
 


### PR DESCRIPTION
### Motivation
- The plugin accepted arbitrary strings from `requestDl` responses and passed them to navigation sinks, allowing dangerous schemes like `javascript:` or `intent:` to reach `window.open`, `opener.location.href`, Android bridges, or anchor `href` values.
- Movie and single-file flows now expose the per-file download action, making this validation gap reachable and creating a high-severity attack path.

### Description
- Added `normalizeSafeDownloadLink(link)` which parses the returned link with `new URL(...)`, trims input, and only accepts `http:` or `https:` schemes otherwise returning `null`.
- Replaced the previous permissive `resolveFileDownloadLink` behavior to call `normalizeSafeDownloadLink(dl?.url || dl?.data)` and throw `torbox_error_file_link` if the normalized link is not present.
- Updated unit assertions in `tests/unit/torbox-pure.test.js` to check for the presence of the normalization helper and its URL/scheme checks so the guard remains enforced.
- Changes touch `torbox-lampa-plugin.js` and `tests/unit/torbox-pure.test.js` and preserve existing download/playback logic while preventing unsafe schemes from reaching navigation APIs.

### Testing
- Ran `npm run validate` which succeeded and reported the plugin version consistency and baseline checks as OK.
- Ran unit tests via `npm run test:unit` which passed all tests (22/22) after the changes.
- Running the full `npm run test` attempted end-to-end Playwright tests but they failed due to missing Chromium binary in the environment, and `npx playwright install chromium` failed with a CDN `403 Domain forbidden` error; the e2e failures are environmental and not caused by the code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a273268b150832b8f4ef311d06f6f84)