### PR TITLE
fix: validate TorBox download URLs

### DIFF
--- a/tests/unit/torbox-pure.test.js
+++ b/tests/unit/torbox-pure.test.js
@@ -88,6 +88,17 @@ function normalizeCustomParsers(customStr = '') {
     .filter(Boolean);
 }
 
+function isSafeDownloadLink(link) {
+  if (!link || typeof link !== 'string') return false;
+
+  try {
+    const url = new URL(link.trim());
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch (_) {
+    return false;
+  }
+}
+
 function normalizeProgress(p) {
   const n = Number(p);
   if (!isFinite(n) || n < 0) return 0;
@@ -360,6 +371,18 @@ test('custom parser URLs are normalized to host (+path), dropping junk and inval
     parsers.map((p) => p.url),
     ['good.example/api', 'plain.example']
   );
+});
+
+test('download link validation only accepts absolute http(s) URLs', () => {
+  assert.equal(isSafeDownloadLink('https://example.com/file.mp4'), true);
+  assert.equal(isSafeDownloadLink('  http://example.com/file.mp4  '), true);
+  assert.equal(isSafeDownloadLink('javascript:alert(1)'), false);
+  assert.equal(isSafeDownloadLink('intent://example/#Intent;scheme=https;end'), false);
+  assert.equal(isSafeDownloadLink('file:///sdcard/download.mp4'), false);
+  assert.equal(isSafeDownloadLink('//example.com/file.mp4'), false);
+  assert.equal(isSafeDownloadLink('/relative/file.mp4'), false);
+  assert.equal(isSafeDownloadLink(''), false);
+  assert.equal(isSafeDownloadLink(null), false);
 });
 
 test('downloadPhase distinguishes downloading / finalizing / ready', () => {
@@ -668,6 +691,9 @@ test('file download action is separate from playback', () => {
   assert.match(plugin, /if \(element\.hasClass\('torbox-file-download'\)\) return FocusZones\.FILE_DOWNLOAD;/);
   assert.match(plugin, /torbox-file-download selector/);
   assert.match(plugin, /const link = await resolveFileDownloadLink\(torrentData, file\);/);
+  assert.match(plugin, /const isSafeDownloadLink = \(link\) =>/);
+  assert.match(plugin, /new URL\(link\.trim\(\)\)/);
+  assert.match(plugin, /url\.protocol === 'http:' \|\| url\.protocol === 'https:'/);
 
   const drawStart = plugin.indexOf('const drawEpisodes = (torrentData, preferredFile = null) => {');
   const drawEnd = plugin.indexOf('const _getPlayerConfig =', drawStart);

--- a/torbox-lampa-plugin.js
+++ b/torbox-lampa-plugin.js
@@ -2123,11 +2123,22 @@ try {
         })[0] || null;
     };
 
+    const isSafeDownloadLink = (link) => {
+      if (!link || typeof link !== 'string') return false;
+
+      try {
+        const url = new URL(link.trim());
+        return url.protocol === 'http:' || url.protocol === 'https:';
+      } catch (_) {
+        return false;
+      }
+    };
+
     const resolveFileDownloadLink = async (torrentData, file) => {
       const dl = await Api.requestDl(torrentData.id, file.id);
       const link = dl?.url || dl?.data;
-      if (!link || typeof link !== 'string') throw { type: 'api', message: translate('torbox_error_file_link') };
-      return link;
+      if (!isSafeDownloadLink(link)) throw { type: 'api', message: translate('torbox_error_file_link') };
+      return link.trim();
     };
 
     const getFileDownloadFilename = (file) => {


### PR DESCRIPTION
### Motivation
- The TorBox `requestdl` result was accepted as any non-empty string and later used as a navigation/intent target, allowing non-HTTP schemes (e.g. `javascript:`, `intent:`) to execute in a same-origin prepared `about:blank` window or be forwarded to Android bridges. 
- The change hardens the download handoff by ensuring only safe absolute `http:`/`https:` URLs are accepted before any navigation, Android bridge, anchor, `window.open`, clipboard, or player handling.

### Description
- Add `isSafeDownloadLink(link)` which calls `new URL(link.trim())` and returns true only for `http:` or `https:` protocols. (file: `torbox-lampa-plugin.js`)
- Replace the prior permissive check in `resolveFileDownloadLink` with `isSafeDownloadLink`, trim the link, and throw a user-visible error when the link is not a safe `http(s)` URL. (file: `torbox-lampa-plugin.js`)
- Add unit helper and tests in `tests/unit/torbox-pure.test.js` that verify `isSafeDownloadLink` accepts absolute `http(s)` URLs and rejects `javascript:`, `intent:`, `file:`, protocol-relative, relative, empty, and non-string values. The tests also assert the presence of the validation helper in the plugin source. (file: `tests/unit/torbox-pure.test.js`)
- The validation now prevents unsafe schemes from reaching `AndroidJS.openBrowser`, `Lampa.Android.openBrowser`, prepared-window navigation (`opener.location.href`), anchor `href`, `window.open`, player, and clipboard flows.

### Testing
- Ran `node --check torbox-lampa-plugin.js` and `npm run test:unit`, and all unit tests passed. 
- Ran `npm test`; unit tests passed but the Playwright e2e suite failed to launch Chromium because Playwright browsers are not installed in the environment (installable via `npx playwright install`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27318c3268832ba269e61846e300ee)