### PR TITLE
fix: validate episode download links

### DIFF
--- a/tests/unit/torbox-pure.test.js
+++ b/tests/unit/torbox-pure.test.js
@@ -691,15 +691,21 @@ test('file download starts a download path after requestdl resolves', () => {
   const pluginPath = path.resolve(__dirname, '..', '..', 'torbox-lampa-plugin.js');
   const plugin = fs.readFileSync(pluginPath, 'utf8');
 
+  assert.match(plugin, /const normalizeHttpDownloadLink = \(link\) =>/);
+  assert.match(plugin, /new URL\(link\.trim\(\)\)/);
+  assert.match(plugin, /url\.protocol !== 'http:' && url\.protocol !== 'https:'\)/);
+  assert.match(plugin, /const link = normalizeHttpDownloadLink\(dl\?\.url \|\| dl\?\.data\);/);
   assert.match(plugin, /const getFileDownloadFilename = \(file\) =>/);
   assert.match(plugin, /const prepareFileDownloadOpen = \(file\) =>/);
   assert.match(plugin, /const startFileDownload = \(link, file, opener\) =>/);
   assert.match(plugin, /document\.createElement\('a'\)/);
   assert.match(plugin, /\.setAttribute\('download', filename\)/);
   assert.match(plugin, /opener\.opener = null/);
+  assert.match(plugin, /opened\.opener = null/);
+  assert.match(plugin, /\.setAttribute\('rel', 'noopener noreferrer'\)/);
   assert.match(plugin, /AndroidJS\.openBrowser\(link\)/);
   assert.match(plugin, /Lampa\.Android\.openBrowser\(link\)/);
-  assert.match(plugin, /window\.open\(link, '_blank', 'noopener'\)/);
+  assert.match(plugin, /window\.open\(link, '_blank', 'noopener,noreferrer'\)/);
   assert.match(plugin, /return 'system';/);
   assert.match(plugin, /return 'attempted';/);
   assert.match(plugin, /return 'copy_only';/);

--- a/torbox-lampa-plugin.js
+++ b/torbox-lampa-plugin.js
@@ -2123,10 +2123,22 @@ try {
         })[0] || null;
     };
 
+    const normalizeHttpDownloadLink = (link) => {
+      if (!link || typeof link !== 'string') return null;
+
+      try {
+        const url = new URL(link.trim());
+        if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+        return url.href;
+      } catch (_) {
+        return null;
+      }
+    };
+
     const resolveFileDownloadLink = async (torrentData, file) => {
       const dl = await Api.requestDl(torrentData.id, file.id);
-      const link = dl?.url || dl?.data;
-      if (!link || typeof link !== 'string') throw { type: 'api', message: translate('torbox_error_file_link') };
+      const link = normalizeHttpDownloadLink(dl?.url || dl?.data);
+      if (!link) throw { type: 'api', message: translate('torbox_error_file_link') };
       return link;
     };
 
@@ -2235,7 +2247,7 @@ try {
         anchor.href = link;
         anchor.setAttribute('download', filename);
         anchor.setAttribute('target', '_blank');
-        anchor.setAttribute('rel', 'noopener');
+        anchor.setAttribute('rel', 'noopener noreferrer');
         anchor.style.display = 'none';
         document.body.appendChild(anchor);
         anchor.click();
@@ -2256,8 +2268,15 @@ try {
     const tryOpenDownloadLink = (link) => {
       try {
         if (typeof window.open === 'function') {
-          const opened = window.open(link, '_blank', 'noopener');
-          if (opened) return true;
+          const opened = window.open(link, '_blank', 'noopener,noreferrer');
+          if (opened) {
+            try {
+              opened.opener = null;
+            } catch (_) {
+              /* ignore cross-window opener failures */
+            }
+            return true;
+          }
         }
       } catch (e) {
         LOG('Download link open failed', e?.message || e);


### PR DESCRIPTION
### Motivation
- Prevent unsafe schemes from being opened from TorBox `requestdl` responses and stop untrusted values (e.g. `javascript:`, `data:`, `intent:`) from executing or invoking external handlers when the episode download button is used.
- Ensure download openings do not retain `window.opener` access and use proper `noopener`/`noreferrer` behavior to reduce risk of exposing privileged context or stored keys.

### Description
- Add `normalizeHttpDownloadLink` which parses the `requestdl` value with `new URL()` and allows only `http:`/`https:` schemes, returning `null` for malformed/unsafe values, and use it from `resolveFileDownloadLink` in `torbox-lampa-plugin.js`.
- Harden download opening fallbacks by setting anchor `rel` to `'noopener noreferrer'` and updating `window.open` to include `'noopener,noreferrer'` and explicitly clear `opened.opener = null` when a window reference is returned.
- Update unit-source assertions in `tests/unit/torbox-pure.test.js` to check for the new `normalizeHttpDownloadLink` usage and the `noopener/noreferrer` + opener-nulling protections.

### Testing
- Ran `node scripts/validate.js` via `npm run validate`, which completed successfully.
- Ran unit tests via `npm run test:unit` (executed `node --test tests/unit/torbox-pure.test.js`) and all unit checks passed (22 tests, 0 failures).
- Ran `npm test` (unit + e2e); unit tests passed but Playwright e2e failed because the Chromium browser binary is not installed in the environment, so e2e did not execute successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a273273aa14832b935a73e00e589837)